### PR TITLE
Implemented dictionary operators for jsonproxy

### DIFF
--- a/mtgjson/jsonproxy.py
+++ b/mtgjson/jsonproxy.py
@@ -2,6 +2,18 @@ class JSONProxy(object):
     def __init__(self, data):
         self.__data = data
 
+    def  __iter__(self):
+        return self.__data.__iter__()
+
+    def __getitem__(self, key):
+        try:
+            return self.__data[key]
+        except KeyError as e:
+            raise AttributeError(e)
+
+    def __contains__(self, item):
+        return self.__data.__contains__(item)
+
     def __getattr__(self, key):
         try:
             return self.__data[key]
@@ -10,3 +22,4 @@ class JSONProxy(object):
 
     def _get_raw_data(self):
         return self.__data
+


### PR DESCRIPTION
The MTG JSON spec states that

> If a value would be empty (such as manaCost for Basic Lands), then the key will not exist in the object.

For this reason, it is useful to test for the existence of keys in a JsonProxy object, e.g. `if 'supertypes' in card`. To this end, I've proxied **iter**, **getitem**, and **contains** onto the __data object.
