### PR TITLE
Add support for empty colors array

### DIFF
--- a/mtgjson/__init__.py
+++ b/mtgjson/__init__.py
@@ -69,7 +69,7 @@ class CardProxy(JSONProxy):
 
         # try creating a pseudo collectors number
         def _getcol(c):
-            if hasattr(c, 'colors'):
+            if hasattr(c, 'colors') and len(c.colors) > 0:
                 if len(c.colors) > 1:
                     return 'Gold'
                 return c.colors[0]


### PR DESCRIPTION
This fixes the `_getcol` function for card objects with a present but empty `colors` array. The fact that this array is missing for colorless cards is considered a bug by at least some of the MTG JSON maintainers and might be fixed at any time.