### PR TITLE
Update for MTG JSON 4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ pyMTGJSon
 =========
 
 A small python library designged to ease to write scripts/apps that use data
-from `mtgjson.com <http://mtgjson.com>`_.
+from `mtgjson.com <https://mtgjson.com>`_.
 
 Example use
 -----------
@@ -11,17 +11,15 @@ Example use
 
     >>> from mtgjson import CardDb
     >>> db = CardDb.from_url()
-    >>> card = db.cards_by_ascii_name['aether vial']
+    >>> card = db.cards_by_name['Aether Vial']
     >>> card.name
     'Aether Vial'
     >>> print(card.name)
     Aether Vial
-    >>> card.cmc
+    >>> card.convertedManaCost
     1
     >>> card.text
     'At the beginning of your upkeep, you may put a charge counter on Aether Vial.\n{T}: You may put a creature card with converted mana cost equal to the number of charge counters on Aether Vial from your hand onto the battlefield.'
-    >>> card.img_url
-    'http://mtgimage.com/set/MMA/aether vial.jpg'
 
 
 See the documentation at http://pythonhosted.org/mtgjson for more.


### PR DESCRIPTION
This removes the following APIs since MTG JSON no longer includes the required data:

* `CardProxy.img_url`
* `CardProxy.ascii_name`
* `SetProxy.cards_by_ascii_name`
* `CardDb.cards_by_ascii_name`