### PR TITLE
MTG JSON version 5 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ pyMTGJSon
 =========
 
 A small python library designged to ease to write scripts/apps that use data
-from `mtgjson.com <http://mtgjson.com>`_.
+from `mtgjson.com <https://mtgjson.com>`_.
 
 Example use
 -----------
@@ -11,17 +11,15 @@ Example use
 
     >>> from mtgjson import CardDb
     >>> db = CardDb.from_url()
-    >>> card = db.cards_by_ascii_name['aether vial']
+    >>> card = db.cards_by_name['Aether Vial']
     >>> card.name
     'Aether Vial'
     >>> print(card.name)
     Aether Vial
-    >>> card.cmc
+    >>> card.convertedManaCost
     1
     >>> card.text
     'At the beginning of your upkeep, you may put a charge counter on Aether Vial.\n{T}: You may put a creature card with converted mana cost equal to the number of charge counters on Aether Vial from your hand onto the battlefield.'
-    >>> card.img_url
-    'http://mtgimage.com/set/MMA/aether vial.jpg'
 
 
 See the documentation at http://pythonhosted.org/mtgjson for more.

--- a/tests/test_mtgjson.py
+++ b/tests/test_mtgjson.py
@@ -4,7 +4,7 @@ import os
 import pytest
 import requests
 
-from mtgjson import CardDb, ALL_SETS_URL, ALL_SETS_X_URL
+from mtgjson import CardDb, ALL_SETS_URL
 
 
 def download_set_file(url, fn):
@@ -22,17 +22,13 @@ def download_set_file(url, fn):
 
 
 @pytest.fixture(scope='module',
-                params=['url', 'file', 'file-x'])
+                params=['url', 'file'])
 def db(request):
     if request.param == 'url':
         return CardDb.from_url()
     elif request.param == 'file':
         return CardDb.from_file(
             download_set_file(ALL_SETS_URL, 'AllSets.json')
-        )
-    elif request.param == 'file-x':
-        return CardDb.from_file(
-            download_set_file(ALL_SETS_X_URL, 'AllSets-x.json')
         )
 
 
@@ -43,7 +39,7 @@ def test_db_instantiation(db):
 def test_get_card_by_name(db):
     card = db.cards_by_name['Sen Triplets']
 
-    assert card.multiverseid == 180607
+    assert card.flavorText == 'They are the masters of your mind.'
 
 
 def test_get_card_by_id(db):
@@ -57,26 +53,26 @@ def test_get_sen_triplets(db):
 
     assert card.name == 'Sen Triplets'
     assert card.manaCost == '{2}{W}{U}{B}'
-    assert card.cmc == 5
-    assert card.colors == ['White', 'Blue', 'Black']
+    assert card.convertedManaCost == 5
+    assert card.colors == ['B', 'U', 'W']
     assert card.type == u'Legendary Artifact Creature — Human Wizard'
     assert card.supertypes == ['Legendary']
     assert card.types == ['Artifact', 'Creature']
     assert card.subtypes == ['Human', 'Wizard']
-    assert card.rarity == 'Mythic Rare'
+    assert card.rarity == 'mythic'
     assert card.text == ('At the beginning of your upkeep, choose target '
                          'opponent. This turn, that player can\'t cast spells '
-                         'or activate abilities and plays with his or her hand'
-                         ' revealed. You may play cards from that player\'s '
-                         'hand this turn.')
-    assert card.flavor == 'They are the masters of your mind.'
+                         'or activate abilities and plays with their hand '
+                         'revealed. You may play lands and cast spells from '
+                         'that player\'s hand this turn.')
+    assert card.flavorText == 'They are the masters of your mind.'
     assert card.artist == 'Greg Staples'
     assert card.number == '109'
     assert card.power == '3'
     assert card.toughness == '3'
     assert card.layout == 'normal'
-    assert card.multiverseid == 180607
-    assert card.imageName == 'sen triplets'
+    assert card.multiverseId == 180607
+    assert card.ascii_name == 'sen triplets'
 
 
 def test_set_list(db):
@@ -108,3 +104,10 @@ def test_different_sets_compare_nonequal(db):
     c2 = db.sets['ISD'].cards[0]
 
     assert c1 < c2
+
+
+def test_urls(db):
+    card = db.cards_by_id[23194]
+
+    assert card.img_url == 'https://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=23194&type=card'
+    assert card.gatherer_url == 'https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=23194'


### PR DESCRIPTION
Started with changes from open pull request by user fenhl for MTG JSON version 4 support, but restored the removed APIs with replacements that work with version 5.

Updated the tests to pass with the latest version.  Note that the test changes for 'Sen Triplets' are due to a re-release of the card in the 2020 FMB1 set.  Removed tests related to deprecated 'AllSets-x.json' file.